### PR TITLE
update clean-css dependency for node 6+

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     }
   },
   "dependencies": {
-    "clean-css": "~3.2.8",
+    "clean-css": "~3.4.8",
     "homunculus": "~0.9.7",
     "glob": "~5.0.10",
     "image-size": "~0.3.5"


### PR DESCRIPTION
If we keep using clean-css@3.2.8, an "TypeError: Path must be a string. Received undefined" will be thrown under node 6+. update clean-css would fix it.
