### PR TITLE
Update clean-css to 3.4.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     }
   },
   "dependencies": {
-    "clean-css": "~3.2.8",
+    "clean-css": "~3.4.21",
     "homunculus": "~0.9.7",
     "glob": "~5.0.10",
     "image-size": "~0.3.5"


### PR DESCRIPTION
I'd recommend bumping this. On Node 6 and above, `more-css` errors out because of a bug in older versions of clean-css. This is resolved in newer versions.