### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -21,11 +21,11 @@ web目录下为书写符合AMD/CMD规范的js文件。
 
 more的核心理念是：原有的浏览器标准不修改，编译后的代码严格保持调试一致，行数不变更，文件对应关系不改变，满足GoToDefine的先决条件。
 
-##INSTALL
+## INSTALL
 
 npm install more-css
 
-##API
+## API
 
 ### More
 * constructor(code:String = '') 传入需要预编译的code

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ web directory for writing compatible with AMD/CMD norms js document.
 
 the core concept: the original browser standards no changes, editing, translation, code, strictly to maintain tuning consistency, the numbers don't change, document the relationship don't change to meet GoToDefine prerequisite.
 
-##INSTALL
+## INSTALL
 
 npm install more-css
 
-##API
+## API
 
 ### More
 * constructor(code:String = '') In need to pre-compile the code


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
